### PR TITLE
View most recent incidents

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+BIKE_INCIDENTS_ROOT=http://bike_incident_root

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 !/tmp/.keep
 
 .byebug_history
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_bot_rails'
   gem 'pry'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'puma', '~> 3.7'
 group :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'
+  gem 'webmock'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'puma', '~> 3.7'
 group :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'
-  gem 'webmock'
+  gem 'webmock', '2.3.1'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
     byebug (10.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.3)
     devise (4.3.0)
       bcrypt (~> 3.0)
@@ -65,6 +67,7 @@ GEM
     ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hashdiff (0.3.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
@@ -143,6 +146,7 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     spring (2.0.2)
@@ -168,6 +172,10 @@ GEM
       rest-client (~> 1.6.7)
     warden (1.2.7)
       rack (>= 1.0)
+    webmock (1.22.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -190,6 +198,7 @@ DEPENDENCIES
   sqlite3
   tzinfo-data
   unirest
+  webmock
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,10 @@ GEM
       devise (> 3.5.2, <= 4.3)
       rails (< 6)
     diff-lcs (1.3)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubi (1.7.0)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
@@ -164,6 +168,7 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
+    timecop (0.7.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unirest (1.1.2)
@@ -186,6 +191,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   devise_token_auth
+  dotenv-rails
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
   pry
@@ -196,6 +202,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  timecop
   tzinfo-data
   unirest
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    hashdiff (0.3.0)
+    hashdiff (0.3.7)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
@@ -168,7 +168,6 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
-    timecop (0.7.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unirest (1.1.2)
@@ -177,7 +176,7 @@ GEM
       rest-client (~> 1.6.7)
     warden (1.2.7)
       rack (>= 1.0)
-    webmock (1.22.6)
+    webmock (2.3.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -202,10 +201,9 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
-  timecop
   tzinfo-data
   unirest
-  webmock
+  webmock (= 2.3.1)
 
 BUNDLED WITH
    1.16.1

--- a/app/controllers/api/v1/incidents_controller.rb
+++ b/app/controllers/api/v1/incidents_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+
+    class IncidentsController < ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def index
+        render json: most_recent_incidents, status: :ok
+      end
+
+      private
+
+      def most_recent_incidents
+        IncidentFetcher.new.latest_incidents
+      end
+    end
+
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,0 @@
-class UsersController < ApplicationController
-  def create
-    User.create(signup_params)
-  end
-
-  def signup_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
-  end
-end

--- a/app/models/incident_fetcher.rb
+++ b/app/models/incident_fetcher.rb
@@ -1,0 +1,18 @@
+class IncidentFetcher
+
+  def latest_incidents
+    Unirest.get incident_root_url,
+                parameters: { occurred_after: yesterday_timestamp },
+                headers: { "Accept" => "application/json" }
+  end
+
+  private
+
+  def incident_root_url
+    ENV["BIKE_INCIDENTS_ROOT"]
+  end
+
+  def yesterday_timestamp
+    Date.yesterday.to_time.to_i
+  end
+end

--- a/bin/setup
+++ b/bin/setup
@@ -18,11 +18,9 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  unless File.exist?('.env')
+    cp '.env.sample', '.env'
+  end
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,10 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      root to: "home#welcome"
       mount_devise_token_auth_for 'User', at: 'auth'
+
+      root to: "home#welcome"
+      resources :incidents
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,7 +16,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include FactoryBot::Syntax::Methods
-  config.include RequestsHelper, type: :request
+  config.include RequestsHelper
+
+  config.before(:each) do
+    stub_request(:get, latest_incidents_request_path).
+      to_return(body: latest_incidents_fixture)
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/api/v1/user_requests_all_incidents_spec.rb
+++ b/spec/requests/api/v1/user_requests_all_incidents_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "User requests all incidents", type: :request do
+
+  describe "GET /api/v1/incidents" do
+    context "when logged in" do
+      it "returns all the incidents" do
+        signed_in_user_request :get, api_v1_incidents_path, params: {}
+
+        expect(json_parsed_body["raw_body"]).to_not be_empty
+      end
+
+      it "returns a 200 http status code" do
+        signed_in_user_request :get, api_v1_incidents_path, params: {}
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when logged out" do
+      it "displays an error message" do
+        get api_v1_incidents_path
+
+        expect(json_parsed_body["errors"]).to be_present
+      end
+
+      it "returns a 401 http status" do
+        get api_v1_incidents_path
+
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+end

--- a/spec/requests/api/v1/visitor_visits_home_spec.rb
+++ b/spec/requests/api/v1/visitor_visits_home_spec.rb
@@ -8,8 +8,4 @@ describe "visitor visits home" do
       expect(json_parsed_body["message"]).to match /Welcome/
     end
   end
-
-  def json_parsed_body
-    JSON.parse(response.body)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/requests_helper.rb
+++ b/spec/support/requests_helper.rb
@@ -10,6 +10,26 @@ module RequestsHelper
     }
   end
 
+  def signed_in_user_request(request_method, request_path, opts = {})
+    user = create(:user, email: "test@test.com",
+                         password: "password")
+    credentials = login_user(email: "test@test.com", password: "password")
+    opts.merge!(headers: credentials)
+    send(request_method, request_path, opts)
+  end
+
+  def latest_incidents_fixture
+    { raw_body: [] }.to_json
+  end
+
+  def latest_incidents_request_path
+    "#{ENV['BIKE_INCIDENTS_ROOT']}?occurred_after=#{yesterday_timestamp}"
+  end
+
+  def yesterday_timestamp
+    Date.yesterday.to_time.to_i
+  end
+
   def json_parsed_body
     JSON.parse(response.body)
   end


### PR DESCRIPTION
On Login to the app, we should be able to view all most recent incidents by default.

This change addresses the need by:
1. Adding the necessary specs to ensure that most recent bike incidents can only be viewed by the logged in user
2. Adding webmock to ensure that there are no external api requests
3. Using environment variables to hold the bike_incidents root_url according to 12factor rules

Resolves #10 