### PR TITLE
Search Incidents

### DIFF
--- a/app/controllers/api/v1/incidents_controller.rb
+++ b/app/controllers/api/v1/incidents_controller.rb
@@ -5,13 +5,13 @@ module Api
       before_action :authenticate_api_v1_user!
 
       def index
-        render json: most_recent_incidents, status: :ok
+        render json: incident_results, status: :ok
       end
 
       private
 
-      def most_recent_incidents
-        IncidentFetcher.new.latest_incidents
+      def incident_results
+        IncidentFetcher.new(params).incident_results
       end
     end
 

--- a/app/models/incident_fetcher.rb
+++ b/app/models/incident_fetcher.rb
@@ -1,12 +1,24 @@
 class IncidentFetcher
 
-  def latest_incidents
+  def initialize(params)
+    @query = params[:query]
+  end
+
+  def incident_results
     Unirest.get incident_root_url,
-                parameters: { occurred_after: yesterday_timestamp },
+                parameters: { occurred_after: occurred_after,
+                              query: query },
                 headers: { "Accept" => "application/json" }
   end
 
   private
+
+  attr_reader :query
+
+  def occurred_after
+    return nil if query.present?
+    yesterday_timestamp
+  end
 
   def incident_root_url
     ENV["BIKE_INCIDENTS_ROOT"]
@@ -15,4 +27,5 @@ class IncidentFetcher
   def yesterday_timestamp
     Date.yesterday.to_time.to_i
   end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,10 @@ RSpec.configure do |config|
 
   config.before(:each) do
     stub_request(:get, latest_incidents_request_path).
-      to_return(body: latest_incidents_fixture)
+      to_return(body: incidents_results_fixture)
+
+    stub_request(:get, "#{incidents_root}?query=Obstruction&occurred_after").
+      to_return(body: incidents_results_fixture)
   end
 end
 

--- a/spec/requests/api/v1/user_searches_incidents_spec.rb
+++ b/spec/requests/api/v1/user_searches_incidents_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe "User searches incidents" do
+
+  describe "GET /api/v1/incidents" do
+    context "when logged in" do
+      it "returns incidents matching the search criteria" do
+        signed_in_user_request :get, api_v1_incidents_path,
+                                     params: { query: "Obstruction" }
+
+        expect(json_parsed_body["raw_body"]).to_not be_empty
+      end
+    end
+
+    context "when not logged in" do
+      it "returns an error message to the user" do
+        get api_v1_incidents_path, params: { query: "Obstruction" }
+
+        expect(json_parsed_body["errors"]).to be_present
+      end
+
+      it "returns a 401 http status to the user" do
+        get api_v1_incidents_path, params: { query: "Obstruction" }
+
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+end

--- a/spec/support/requests_helper.rb
+++ b/spec/support/requests_helper.rb
@@ -18,12 +18,16 @@ module RequestsHelper
     send(request_method, request_path, opts)
   end
 
-  def latest_incidents_fixture
+  def incidents_results_fixture
     { raw_body: [] }.to_json
   end
 
   def latest_incidents_request_path
-    "#{ENV['BIKE_INCIDENTS_ROOT']}?occurred_after=#{yesterday_timestamp}"
+    "#{incidents_root}?occurred_after=#{yesterday_timestamp}&query"
+  end
+
+  def incidents_root
+    ENV['BIKE_INCIDENTS_ROOT']
   end
 
   def yesterday_timestamp


### PR DESCRIPTION
Users should be able to search incidents via the incident name

This change addresses the need by:
1. Adding the necessary specs to ensure that only a logged in user can search
2. Ensure all specs by having the necessary implementation within `IncidentFetcher`

Resolves #3 