### PR TITLE
View Individual Incidents

### DIFF
--- a/app/controllers/api/v1/incidents_controller.rb
+++ b/app/controllers/api/v1/incidents_controller.rb
@@ -5,13 +5,25 @@ module Api
       before_action :authenticate_api_v1_user!
 
       def index
-        render json: incident_results, status: :ok
+        render json: incidents_results, status: :ok
+      end
+
+      def show
+        render json: incident_result, status: :ok
       end
 
       private
 
-      def incident_results
-        IncidentFetcher.new(params).incident_results
+      def incidents_results
+        incident_fetcher.incident_results
+      end
+
+      def incident_result
+        incident_fetcher.incident_result
+      end
+
+      def incident_fetcher
+        IncidentFetcher.new(params)
       end
     end
 

--- a/app/models/incident_fetcher.rb
+++ b/app/models/incident_fetcher.rb
@@ -2,26 +2,36 @@ class IncidentFetcher
 
   def initialize(params)
     @query = params[:query]
+    @id = params[:id]
   end
 
   def incident_results
-    Unirest.get incident_root_url,
+    Unirest.get incidents_root_url,
                 parameters: { occurred_after: occurred_after,
                               query: query },
                 headers: { "Accept" => "application/json" }
   end
 
+  def incident_result
+    Unirest.get incident_url,
+                headers: { "Accept" => "application/json" }
+  end
+
   private
 
-  attr_reader :query
+  attr_reader :query, :id
 
   def occurred_after
     return nil if query.present?
     yesterday_timestamp
   end
 
-  def incident_root_url
+  def incidents_root_url
     ENV["BIKE_INCIDENTS_ROOT"]
+  end
+
+  def incident_url
+    "#{incidents_root_url}/#{id}"
   end
 
   def yesterday_timestamp

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User', at: 'auth'
 
       root to: "home#welcome"
-      resources :incidents
+      resources :incidents, only: [:index, :show]
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,9 @@ RSpec.configure do |config|
 
     stub_request(:get, "#{incidents_root}?query=Obstruction&occurred_after").
       to_return(body: incidents_results_fixture)
+
+    stub_request(:get, "#{incidents_root}/1").
+      to_return(body: incident_result_fixture)
   end
 end
 

--- a/spec/requests/api/v1/user_requests_an_incident_spec.rb
+++ b/spec/requests/api/v1/user_requests_an_incident_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "User requests an incident", type: :request do
+  describe "GET /api/v1/incidents/:id" do
+    context "when logged in" do
+      it "returns all the incidents" do
+        signed_in_user_request :get, api_v1_incident_path(id: 1), params: {}
+
+        expect(json_parsed_body["raw_body"]).to_not be_empty
+      end
+
+      it "returns a 200 http status code" do
+        signed_in_user_request :get, api_v1_incident_path(id: 1), params: {}
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when logged out" do
+      it "displays an error message" do
+        get api_v1_incident_path(id: 1)
+
+        expect(json_parsed_body["errors"]).to be_present
+      end
+
+      it "returns a 401 http status" do
+        get api_v1_incident_path(id: 1)
+
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+end

--- a/spec/support/requests_helper.rb
+++ b/spec/support/requests_helper.rb
@@ -22,6 +22,10 @@ module RequestsHelper
     { raw_body: [] }.to_json
   end
 
+  def incident_result_fixture
+    { incident: { id: 1, title: "Obstruction" } }.to_json
+  end
+
   def latest_incidents_request_path
     "#{incidents_root}?occurred_after=#{yesterday_timestamp}&query"
   end


### PR DESCRIPTION
Users should be able to view individual incidents.

This change addresses the need by:
1. Adding the necessary specs to ensure that only a logged in user can view an incident
2. Doing the necessary implementation within the IncidentController and IncidentFetcher classes to ensure that specs pass.

Resolves #4 