### PR TITLE
Make App deployable to Heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,16 @@ version: 2
 jobs:
   build:
     docker:
-       - image: circleci/ruby:2.4.1-node-browsers
+       - image: circleci/ruby:2.3.4-node-browsers
+         environment:
+           RAILS_ENV: test
+           PGHOST: 127.0.0.1
+           DATABASE_URL: postgres://bike_incident@127.0.0.1/bike_incident_test
+       - image: circleci/postgres:9.6
+         environment:
+           POSTGRES_USER: bike_incident
+           POSTGRES_DB: bike_incident_test
+           POSTGRES_PASSWORD: ""
 
     working_directory: ~/repo
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'rails', '~> 5.1.0'
-gem 'sqlite3'
+gem 'pg'
 gem 'devise_token_auth'
 gem 'unirest'
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ group :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'webmock', '2.3.1'
-  gem 'sqlite3'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'webmock', '2.3.1'
+  gem 'sqlite3'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
+    pg (1.0.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -165,7 +166,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -193,6 +193,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
+  pg
   pry
   puma (~> 3.7)
   rails (~> 5.1.0)
@@ -200,7 +201,6 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   tzinfo-data
   unirest
   webmock (= 2.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -201,6 +202,7 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
+  sqlite3
   tzinfo-data
   unirest
   webmock (= 2.3.1)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,5 @@
+class HomeController < ApplicationController
+  def welcome
+    redirect_to api_v1_root_path
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,19 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: bike_incident_dev
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  host: localhost
+  database: bike_incident_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: bike_incident_prod
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,20 +1,17 @@
 default: &default
-  encoding: unicode
+  adapter: postgresql
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  adapter: postgresql
   database: bike_incident_dev
 
 test:
   <<: *default
-  adapter: sqlite3
-  database: db/test.sqlite3
+  database: bike_incident_test
 
 production:
   <<: *default
-  adapter: postgresql
   database: bike_incident_prod
   url: <%= ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,19 +1,20 @@
 default: &default
-  adapter: postgresql
   encoding: unicode
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
+  adapter: postgresql
   database: bike_incident_dev
 
 test:
   <<: *default
-  host: localhost
-  database: bike_incident_test
+  adapter: sqlite3
+  database: db/test.sqlite3
 
 production:
   <<: *default
+  adapter: postgresql
   database: bike_incident_prod
   url: <%= ENV['DATABASE_URL'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.action_mailer.default_url_options = {
+    host: "https://bike-incident.herokuapp.com/api/v1/incidents"
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
     end
   end
 
+  root to: "home#welcome"
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,9 @@
 
 ActiveRecord::Schema.define(version: 20180228113406) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe HomeController, type: :controller do
+
+  describe "#welcome" do
+    it "redirects the user to the api_v1_root_path" do
+      get :welcome
+
+      expect(response).to redirect_to(api_v1_root_path)
+    end
+  end
+
+end


### PR DESCRIPTION
The application at its current state cannot be deployed to heroku because it uses sqlite gem.

This change addresses the need by:

- Removing the sqlite gem
- Adding the necessary pg config
- Defining a root_path

Resolves #13 